### PR TITLE
Checking TF 1.6 + Spark 2.3 + Python 3.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,16 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+
+[packages]
+ipython = "*"
+pandas = ">=0.19.1"
+coverage = ">=4.4.1"
+h5py = ">=2.7.0"
+Keras = "==2.1.5"
+nose = ">=1.3.7"
+numpy = ">=1.11.2"
+parameterized = ">=0.6.1"
+Pillow = "<4.2,>=4.1.1"
+Pygments = ">=2.2.0"
+tensorflow = "==1.6.0"

--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,10 @@ libraryDependencies += "org.tensorflow" % "libtensorflow_jni" % "1.6.0"
 
 assemblyMergeStrategy in assembly := {
   case "requirements.txt" => MergeStrategy.concat
+  case PathList("org", "tensorflow", xs @ _*) => MergeStrategy.first
+  case PathList("org", "slf4j", xs @ _*) => MergeStrategy.first
+  case PathList("org", "scalactic", xs @ _*) => MergeStrategy.first
+  case PathList("com", "typesafeøooooo", xs @ _*) => MergeStrategy.first
   case x =>
     val oldStrategy = (assemblyMergeStrategy in assembly).value
     oldStrategy(x)


### PR DESCRIPTION
@tomasatdatabricks I was able to run _successfully_ the tests using python3. I could not get a way to have pipenv produce a reliable environment for python2.

Here is how to reproduce an environment that should be identical, hopefully. Make sure that you install pipenv, which produces reliably a python environment:
https://docs.pipenv.org/install/#installing-pipenv
(nothing else to do after that)

Tensorframes, using your branch:

```bash
git checkout d4ce7e3a570b63acaeb586af86c330e7f132a6fc
build/sbt clean tfs_testing/assembly
 cp ./target/testing/scala-2.11/tensorframes-assembly-0.3.0.jar ../spark-deep-learning/lib/
```

Spark deep learning, using your branch. It required some changes during the assembly phase.

```bash
# your branch
git checkout c5f35fb264af58e5ed9125e32c58098015133335

pipenv install -r python/requirements.txt
pipenv update
pipenv shell # this will drop you into the virtualenv shell
export PYTHONPATH=`pipenv --venv`
PYSPARK_PYTHON=python3 SCALA_VERSION=2.11.8 SPARK_VERSION=2.3.0 ./python/run-tests.sh
./python/tests/transformers/keras_image_test.py
```

This passes tests with 10^-6 precision.

Since python2 is end-of-life, and since all DL environments are geared toward python3.5+, I recommend that we drop python2 support, at least for testing, and commit to best effort to support python2. Tensorflow itself is already giving warnings for not using python 3.6.
